### PR TITLE
Include options parameter for child_process.spawn function call

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,8 @@ This method receives a URI of a file and stops containers, removes containers, n
   Name | Type | Description 
   -----|------|-------------
   **file** | `string` | **Required.** The file where the service is described. 
-  **options** | `[string]` | **Optional.** Docker compose down commad [options](https://docs.docker.com/compose/reference/down/).
+  **args** | `[string]` | **Optional.** Docker compose down commad [options](https://docs.docker.com/compose/reference/down/).
+  **options** | `[string]` | **Optional.** NodeJS child_process.spawn [options](https://nodejs.org/docs/latest-v6.x/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 #### Example
 
@@ -74,7 +75,8 @@ This method receives a URI of a file and stops running containers without removi
   Name | Type | Description 
   -----|------|-------------
   **file** | `string` | **Required.** The file where the service is described. 
-  **options** | `[string]` | **Optional.** Docker compose stop commad [options](https://docs.docker.com/compose/reference/stop/).
+  **args** | `[string]` | **Optional.** Docker compose stop commad [options](https://docs.docker.com/compose/reference/stop/).
+  **options** | `[string]` | **Optional.** NodeJS child_process.spawn [options](https://nodejs.org/docs/latest-v6.x/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 #### Example
 
@@ -98,7 +100,8 @@ This method receives a URI of a file and sStarts existing containers for a servi
   Name | Type | Description 
   -----|------|-------------
   **file** | `string` | **Required.** The file where the service is described. 
-  **options** | `[string]` | **Optional.** Docker compose start commad [options](https://docs.docker.com/compose/reference/start/).
+  **args** | `[string]` | **Optional.** Docker compose start commad [options](https://docs.docker.com/compose/reference/start/).
+  **options** | `[string]` | **Optional.** NodeJS child_process.spawn [options](https://nodejs.org/docs/latest-v6.x/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 #### Example
 
@@ -123,7 +126,8 @@ This method receives a container name and the command will be executed inside of
   -----|------|-------------
   **container** | `string` | **Required.** The container where the command will be executed.
   **exec_command** | `[string]` | **Required.** The command which will be executed.
-  **options** | `[string]` | **Optional.** Docker exec commad [options](https://docs.docker.com/engine/reference/commandline/exec/).
+  **args** | `[string]` | **Optional.** Docker exec commad [options](https://docs.docker.com/engine/reference/commandline/exec/).
+  **options** | `[string]` | **Optional.** NodeJS child_process.spawn [options](https://nodejs.org/docs/latest-v6.x/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 #### Example
 
@@ -148,7 +152,8 @@ This method receives a container and retrun a promise that resolves the ip of it
   Name | Type | Description 
   -----|------|-------------
   **container** | `string` | **Required.** The container for quering.
-  **options** | `object` | **Optional.** This object has only one field: `options.network`. This is the network where the container is attached.
+  **args** | `object` | **Optional.** This object has only one field: `options.network`. This is the network where the container is attached.
+  **options** | `[string]` | **Optional.** NodeJS child_process.spawn [options](https://nodejs.org/docs/latest-v6.x/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 #### Example
 
@@ -172,6 +177,7 @@ This method receives a container and retrun a promise that resolves the port on 
   Name | Type | Description 
   -----|------|-------------
   **container** | `string` | **Required.** The container for quering.
+  **options** | `[string]` | **Optional.** NodeJS child_process.spawn [options](https://nodejs.org/docs/latest-v6.x/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 #### Example
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,8 @@ This method receives a URI of a file and builds, (re)creates, starts, and attach
   Name | Type | Description 
   -----|------|-------------
   **file** | `string` | **Required.** The file where the service is described. 
-  **options** | `[string]` | **Optional.** Docker compose up commad [options](https://docs.docker.com/compose/reference/up/).
+  **args** | `[string]` | **Optional.** Docker compose up commad [options](https://docs.docker.com/compose/reference/up/).
+  **options** | `[string]` | **Optional.** NodeJS child_process.spawn [options](https://nodejs.org/docs/latest-v6.x/api/child_process.html#child_process_child_process_spawn_command_args_options).
 
 #### Example
 

--- a/src/cmd/cmd.js
+++ b/src/cmd/cmd.js
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.*/
 'use strict';
 
 /**
- * Command line interface 
+ * Command line interface
  * @module docker-compose-manager/cmd
  */
 
@@ -31,14 +31,19 @@ module.exports = {
     /**
      * Method for execute command
      * @param {string} command - The command to be executed.
+     * @param {object} args - Arguments object.
      * @param {object} options - Options object.
      * @return {Promise} A promise.
      */
-    execCommand: (command, options) => {
+    execCommand: (command, args, options) => {
+        if (typeof options === 'undefined') {
+            options = {}
+        }
+
         return new Promise((resolve, reject) => {
             var cmd;
             try {
-                cmd = spawn(command, options);
+                cmd = spawn(command, args, options);
                 resolve(cmd);
             } catch (e) {
                 reject(e);

--- a/src/docker-compose-manager.js
+++ b/src/docker-compose-manager.js
@@ -32,7 +32,7 @@ module.exports = {
      * Docker compose up command. This up a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be upped.
      * @param {object} args - Arguments object.
-     * @param {object} options - Options object.
+     * @param {object} options - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerComposeUp: dockerComposeUp,
@@ -40,7 +40,8 @@ module.exports = {
     /**
      * Docker compose down command. This down a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be down.
-     * @param {object} options - Options object.
+     * @param {object} args - Arguments object.
+     * @param {object} options - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerComposeDown: dockerComposeDown,
@@ -48,7 +49,8 @@ module.exports = {
     /**
      * Docker compose stop command. This stop a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be stopped.
-     * @param {object} options - Options object.
+     * @param {object} args - Arguments object.
+     * @param {object} options - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerComposeStop: dockerComposeStop,
@@ -56,7 +58,8 @@ module.exports = {
     /**
      * Docker compose start command. This start a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be started.
-     * @param {object} options - Options object.
+     * @param {object} args - Arguments object.
+     * @param {object} options - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerComposeStart: dockerComposeStart,
@@ -65,7 +68,8 @@ module.exports = {
      * Docker exec command. This execute a command on the container given
      * @param {string} container - The container where the command will be executed.
      * @param {object} exec_command - The command will be executed
-     * @param {string} options - Options object.
+     * @param {string} args - Arguments object.
+     * @param {object} options - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerExec: dockerExec,
@@ -73,7 +77,8 @@ module.exports = {
     /**
      * This method return the IP of a container given
      * @param {string} container - The container that will be inspected.
-     * @param {string} options - Options object. options.network
+     * @param {string} args - Options object. options.network
+     * @param {object} options - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerInspectIPAddressOfContainer: dockerInspectIPAddressOfContainer,
@@ -81,7 +86,7 @@ module.exports = {
     /**
      * This method return the PORT of a container given
      * @param {string} container - The container that will be inspected.
-     * @param {string} options - Options object. options.network
+     * @param {object} options - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerInspectPortOfContainer: dockerInspectPortOfContainer
@@ -111,14 +116,14 @@ function dockerComposeUp(file, args, options) {
     });
 }
 
-function dockerComposeDown(file, options) {
+function dockerComposeDown(file, args, options) {
     return new Promise((resolve, reject) => {
-        options = options ? options : [];
+        args = args ? args : [];
         var command = 'docker-compose';
-        var arg = ['-f', file, 'down'].concat(options);
+        var arg = ['-f', file, 'down'].concat(args);
 
         var out = "";
-        cmd.execCommand(command, arg).then(child => {
+        cmd.execCommand(command, arg, options).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -129,14 +134,14 @@ function dockerComposeDown(file, options) {
     });
 }
 
-function dockerComposeStop(file, options) {
+function dockerComposeStop(file, args, options) {
     return new Promise((resolve, reject) => {
-        options = options ? options : [];
+        args = args ? args : [];
         var command = 'docker-compose';
-        var arg = ['-f', file, 'stop'].concat(options);
+        var arg = ['-f', file, 'stop'].concat(args);
 
         var out = "";
-        cmd.execCommand(command, arg).then(child => {
+        cmd.execCommand(command, arg, options).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -147,14 +152,14 @@ function dockerComposeStop(file, options) {
     });
 }
 
-function dockerComposeStart(file, options) {
+function dockerComposeStart(file, args, options) {
     return new Promise((resolve, reject) => {
-        options = options ? options : [];
+        args = args ? args : [];
         var command = 'docker-compose';
-        var arg = ['-f', file, 'start'].concat(options);
+        var arg = ['-f', file, 'start'].concat(args);
 
         var out = "";
-        cmd.execCommand(command, arg).then(child => {
+        cmd.execCommand(command, arg, options).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -165,14 +170,14 @@ function dockerComposeStart(file, options) {
     });
 }
 
-function dockerExec(container, exec_command, options) {
+function dockerExec(container, exec_command, args, options) {
     return new Promise((resolve, reject) => {
-        options = options ? options : [];
+        args = args ? args : [];
         var command = 'docker';
-        var arg = ['exec'].concat(options).concat(container).concat(exec_command);
+        var arg = ['exec'].concat(args).concat(container).concat(exec_command);
 
         var out = "";
-        cmd.execCommand(command, arg).then(child => {
+        cmd.execCommand(command, arg, options).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -183,14 +188,14 @@ function dockerExec(container, exec_command, options) {
     });
 }
 
-function dockerInspectIPAddressOfContainer(container, options) {
+function dockerInspectIPAddressOfContainer(container, args, options) {
     return new Promise((resolve, reject) => {
-        options = options ? options : [];
+        args = args ? args : [];
         var command = 'docker';
-        var arg = ['inspect', '--format', "'{{.NetworkSettings.Networks." + options.network + ".IPAddress}}'", container];
+        var arg = ['inspect', '--format', "'{{.NetworkSettings.Networks." + args.network + ".IPAddress}}'", container];
 
         var out = "";
-        cmd.execCommand(command, arg).then(child => {
+        cmd.execCommand(command, arg, options).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -201,14 +206,14 @@ function dockerInspectIPAddressOfContainer(container, options) {
     });
 }
 
-function dockerInspectPortOfContainer(container) {
+function dockerInspectPortOfContainer(container, options) {
     return new Promise((resolve, reject) => {
         // options = options ? options : [];
         var command = 'docker';
         var arg = ['inspect', '--format', "'{{.NetworkSettings.Ports}}'", container];
 
         var out = "";
-        cmd.execCommand(command, arg).then(child => {
+        cmd.execCommand(command, arg, options).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {

--- a/src/docker-compose-manager.js
+++ b/src/docker-compose-manager.js
@@ -31,6 +31,7 @@ module.exports = {
     /**
      * Docker compose up command. This up a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be upped.
+     * @param {object} args - Arguments object.
      * @param {object} options - Options object.
      * @return {Promise} A promise.
      */
@@ -86,25 +87,25 @@ module.exports = {
     dockerInspectPortOfContainer: dockerInspectPortOfContainer
 };
 
-function dockerComposeUp(file, options) {
+function dockerComposeUp(file, args, options) {
     return new Promise((resolve, reject) => {
-        options = options ? options : [];
+        args = args ? args : [];
         var command = 'docker-compose';
 
         var defaultOptions = ['-f', file, 'up', '-d'];
-        if (options.indexOf('--abort-on-container-exit') > -1) {
+        if (args.indexOf('--abort-on-container-exit') > -1) {
             defaultOptions = ['-f', file, 'up'];
         }
 
-        var arg = defaultOptions.concat(options);
-
+        var arg = defaultOptions.concat(args);
         var out = "";
-        cmd.execCommand(command, arg).then(child => {
+
+        cmd.execCommand(command, arg, options).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
                 if (!code) resolve(out);
-                else reject({ code: code, err: out });
+                else reject({code: code, err: out});
             });
         });
     });
@@ -122,7 +123,7 @@ function dockerComposeDown(file, options) {
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
                 if (!code) resolve(out);
-                else reject({ code: code, err: out });
+                else reject({code: code, err: out});
             });
         });
     });
@@ -140,7 +141,7 @@ function dockerComposeStop(file, options) {
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
                 if (!code) resolve(out);
-                else reject({ code: code, err: out });
+                else reject({code: code, err: out});
             });
         });
     });
@@ -158,7 +159,7 @@ function dockerComposeStart(file, options) {
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
                 if (!code) resolve(out);
-                else reject({ code: code, err: out });
+                else reject({code: code, err: out});
             });
         });
     });
@@ -176,7 +177,7 @@ function dockerExec(container, exec_command, options) {
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
                 if (!code) resolve(out);
-                else reject({ code: code, err: out });
+                else reject({code: code, err: out});
             });
         });
     });
@@ -194,7 +195,7 @@ function dockerInspectIPAddressOfContainer(container, options) {
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
                 if (!code) resolve(out.toString('utf-8').replace(/(?:\r\n|\r|\n)/g, '').replace(/'/ig, ''));
-                else reject({ code: code, err: out });
+                else reject({code: code, err: out});
             });
         });
     });
@@ -212,7 +213,7 @@ function dockerInspectPortOfContainer(container) {
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
                 if (!code) resolve(out.toString('utf-8').replace(/(?:\r\n|\r|\n)/g, '').split("[")[1].split("/")[0].replace(/'/ig, ''));
-                else reject({ code: code, err: out });
+                else reject({code: code, err: out});
             });
         });
     });

--- a/src/docker-compose-manager.js
+++ b/src/docker-compose-manager.js
@@ -32,7 +32,7 @@ module.exports = {
      * Docker compose up command. This up a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be upped.
      * @param {object} args - Arguments object.
-     * @param {object} options - child_process.spawn options.
+     * @param {object} processOpt - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerComposeUp: dockerComposeUp,
@@ -41,7 +41,7 @@ module.exports = {
      * Docker compose down command. This down a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be down.
      * @param {object} args - Arguments object.
-     * @param {object} options - child_process.spawn options.
+     * @param {object} processOpt - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerComposeDown: dockerComposeDown,
@@ -50,7 +50,7 @@ module.exports = {
      * Docker compose stop command. This stop a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be stopped.
      * @param {object} args - Arguments object.
-     * @param {object} options - child_process.spawn options.
+     * @param {object} processOpt - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerComposeStop: dockerComposeStop,
@@ -59,7 +59,7 @@ module.exports = {
      * Docker compose start command. This start a docker-compose.yaml given
      * @param {string} file - The file with docker-componse that will be started.
      * @param {object} args - Arguments object.
-     * @param {object} options - child_process.spawn options.
+     * @param {object} processOpt - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerComposeStart: dockerComposeStart,
@@ -69,7 +69,7 @@ module.exports = {
      * @param {string} container - The container where the command will be executed.
      * @param {object} exec_command - The command will be executed
      * @param {string} args - Arguments object.
-     * @param {object} options - child_process.spawn options.
+     * @param {object} processOpt - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerExec: dockerExec,
@@ -78,7 +78,7 @@ module.exports = {
      * This method return the IP of a container given
      * @param {string} container - The container that will be inspected.
      * @param {string} args - Options object. options.network
-     * @param {object} options - child_process.spawn options.
+     * @param {object} processOpt - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerInspectIPAddressOfContainer: dockerInspectIPAddressOfContainer,
@@ -86,13 +86,13 @@ module.exports = {
     /**
      * This method return the PORT of a container given
      * @param {string} container - The container that will be inspected.
-     * @param {object} options - child_process.spawn options.
+     * @param {object} processOpt - child_process.spawn options.
      * @return {Promise} A promise.
      */
     dockerInspectPortOfContainer: dockerInspectPortOfContainer
 };
 
-function dockerComposeUp(file, args, options) {
+function dockerComposeUp(file, args, processOpt) {
     return new Promise((resolve, reject) => {
         args = args ? args : [];
         var command = 'docker-compose';
@@ -105,7 +105,7 @@ function dockerComposeUp(file, args, options) {
         var arg = defaultOptions.concat(args);
         var out = "";
 
-        cmd.execCommand(command, arg, options).then(child => {
+        cmd.execCommand(command, arg, processOpt).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -116,14 +116,14 @@ function dockerComposeUp(file, args, options) {
     });
 }
 
-function dockerComposeDown(file, args, options) {
+function dockerComposeDown(file, args, processOpt) {
     return new Promise((resolve, reject) => {
         args = args ? args : [];
         var command = 'docker-compose';
         var arg = ['-f', file, 'down'].concat(args);
 
         var out = "";
-        cmd.execCommand(command, arg, options).then(child => {
+        cmd.execCommand(command, arg, processOpt).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -134,14 +134,14 @@ function dockerComposeDown(file, args, options) {
     });
 }
 
-function dockerComposeStop(file, args, options) {
+function dockerComposeStop(file, args, processOpt) {
     return new Promise((resolve, reject) => {
         args = args ? args : [];
         var command = 'docker-compose';
         var arg = ['-f', file, 'stop'].concat(args);
 
         var out = "";
-        cmd.execCommand(command, arg, options).then(child => {
+        cmd.execCommand(command, arg, processOpt).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -152,14 +152,14 @@ function dockerComposeStop(file, args, options) {
     });
 }
 
-function dockerComposeStart(file, args, options) {
+function dockerComposeStart(file, args, processOpt) {
     return new Promise((resolve, reject) => {
         args = args ? args : [];
         var command = 'docker-compose';
         var arg = ['-f', file, 'start'].concat(args);
 
         var out = "";
-        cmd.execCommand(command, arg, options).then(child => {
+        cmd.execCommand(command, arg, processOpt).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -170,14 +170,14 @@ function dockerComposeStart(file, args, options) {
     });
 }
 
-function dockerExec(container, exec_command, args, options) {
+function dockerExec(container, exec_command, args, processOpt) {
     return new Promise((resolve, reject) => {
         args = args ? args : [];
         var command = 'docker';
         var arg = ['exec'].concat(args).concat(container).concat(exec_command);
 
         var out = "";
-        cmd.execCommand(command, arg, options).then(child => {
+        cmd.execCommand(command, arg, processOpt).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -188,14 +188,14 @@ function dockerExec(container, exec_command, args, options) {
     });
 }
 
-function dockerInspectIPAddressOfContainer(container, args, options) {
+function dockerInspectIPAddressOfContainer(container, args, processOpt) {
     return new Promise((resolve, reject) => {
         args = args ? args : [];
         var command = 'docker';
         var arg = ['inspect', '--format', "'{{.NetworkSettings.Networks." + args.network + ".IPAddress}}'", container];
 
         var out = "";
-        cmd.execCommand(command, arg, options).then(child => {
+        cmd.execCommand(command, arg, processOpt).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {
@@ -206,14 +206,14 @@ function dockerInspectIPAddressOfContainer(container, args, options) {
     });
 }
 
-function dockerInspectPortOfContainer(container, options) {
+function dockerInspectPortOfContainer(container, processOpt) {
     return new Promise((resolve, reject) => {
         // options = options ? options : [];
         var command = 'docker';
         var arg = ['inspect', '--format', "'{{.NetworkSettings.Ports}}'", container];
 
         var out = "";
-        cmd.execCommand(command, arg, options).then(child => {
+        cmd.execCommand(command, arg, processOpt).then(child => {
             child.stdout.on('data', data => out += data.toString());
             child.stderr.on('data', data => out += data.toString());
             child.on('close', code => {


### PR DESCRIPTION
When is required setup environments variables it can be done in the last parameter of child_process.spawn function. This pull request include support for this parameter.